### PR TITLE
Ensure we don't use aws-sdk v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 rvm:
 - 1.9.3
 - 2.0.0
@@ -9,13 +10,3 @@ script:
 - cd $TRAVIS_BUILD_DIR
 - rake build
 - gem install pkg/*.gem
-- bundle_cache_install
-after_script:
-- bundle_cache
-env:
-  global:
-  - BUNDLE_ARCHIVE="bundle_cache_test"
-  - AWS_S3_BUCKET="travis.data-axle.infogroup.com"
-  - secure: OpVVRrTLeXspiOE0TMXxah7QHPZasA4n+xf9XUwTh0Tq1z6F6Ojq8kz8XvRQOS9VsWKj5Xx8gmrJbzUx2MmKbJZvKi0f19oqJiEstVVfR+ATWzTaDkfl31WUowmvX7QVh8+ejfi9bQDMj9HkAkn6p0uGWZGDZQd5Q/OyVMka/9o=
-  - AWS_ACCESS_KEY_ID=$AWS_S3_KEY
-  - AWS_SECRET_ACCESS_KEY=$AWS_S3_SECRET

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,5 @@ env:
   - BUNDLE_ARCHIVE="bundle_cache_test"
   - AWS_S3_BUCKET="travis.data-axle.infogroup.com"
   - secure: OpVVRrTLeXspiOE0TMXxah7QHPZasA4n+xf9XUwTh0Tq1z6F6Ojq8kz8XvRQOS9VsWKj5Xx8gmrJbzUx2MmKbJZvKi0f19oqJiEstVVfR+ATWzTaDkfl31WUowmvX7QVh8+ejfi9bQDMj9HkAkn6p0uGWZGDZQd5Q/OyVMka/9o=
+  - AWS_ACCESS_KEY_ID=$AWS_S3_KEY
+  - AWS_SECRET_ACCESS_KEY=$AWS_S3_SECRET

--- a/bundle_cache.gemspec
+++ b/bundle_cache.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "aws-sdk", ">= 1.0.0"
+  spec.add_dependency "aws-sdk", "~> 1.0"
   spec.add_dependency "bundler", "~> 1.3"
 
   spec.add_development_dependency "rake"


### PR DESCRIPTION
v2 will NOT be backwards compatible with v1. This keeps the gem from accidentally loading the v2 pre-release.